### PR TITLE
Added 3DS SRAM cache

### DIFF
--- a/build/3DS/Makefile
+++ b/build/3DS/Makefile
@@ -42,6 +42,7 @@ SOURCES		:=	../../src/platforms/3DS\
 				../../src/shared_libs/SDL\
 				../../src/shared_libs/SDL/audio\
 				../../src/core/audio\
+				../../src/shared_libs\
 #DATA		:=	data
 INCLUDES	:=	include
 ROMFS		:=	data

--- a/src/core/mmu/mbc.c
+++ b/src/core/mmu/mbc.c
@@ -10,6 +10,7 @@
 
 #include "../../non_core/logger.h"
 #include "../../non_core/files.h"
+#include "../../non_core/get_time.h"
 
 #include <string.h>
 #include <stdlib.h>
@@ -36,15 +37,43 @@ unsigned RAM_bank_count = 0;
 unsigned ROM_bank_count = 0;
 static int mbc3_rtc = 0;
 
+// SRAM cache is where we store any writes to the SRAM, we only write to the SRAM file every SRAM_WRITE_DELAY milliseconds
+// used to improve 3DS performance and avoid taxing I/O writes
+static unsigned char *SRAM_cache; // max 16 * 8KB ram banks (128KB) 0x2000
+static uint64_t time_last_SRAM_write = 0;   // in ms
+static int SRAM_cache_valid = 0;    // 0 = false, 1 = true, is the cache safe to use for loading
+
 void write_SRAM() {
+
+    log_message(LOG_INFO, "write SRAM called\n");
+    // if sufficent time has passed since last file write, write to the .sav file
+    if(get_time() - time_last_SRAM_write > SRAM_WRITE_DELAY){
+        save_SRAM(SRAM_filename, RAM_banks, RAM_bank_count * 0x2000);
+    }
+    // always save to cache that way any load SRAM calls can use the cache
+    save_SRAM_cached(SRAM_cache, RAM_banks, RAM_bank_count * 0x2000);
+
+    time_last_SRAM_write = get_time();
+    SRAM_cache_valid = 1;   // since we always ensure the cache matches the file, it's always valid except on load up
+}
+
+void flush_SRAM() {
     save_SRAM(SRAM_filename, RAM_banks, RAM_bank_count * 0x2000);
 }
 
 
 void read_SRAM() {
 
+    log_message(LOG_INFO, "read SRAM called\n");
     size_t len;
-    if((len = load_SRAM(SRAM_filename, RAM_banks, RAM_bank_count * 0x2000))) {
+    if(SRAM_cache_valid){  // depending on if the cache is loaded, use cache or the file
+        len = load_SRAM_cached(SRAM_cache, RAM_banks, RAM_bank_count * 0x2000);
+    }
+    else{
+        len = load_SRAM(SRAM_filename, RAM_banks, RAM_bank_count * 0x2000);
+    }
+
+    if(len) {
         if (len !=( RAM_bank_count * 0x2000)) { // Not enough read in
             memset(RAM_banks, 0, len); //"Erase" what just got read into memory
         }
@@ -100,6 +129,7 @@ static void create_SRAM_filename(const char *filename) {
 void teardown_MBC() {
    free(RAM_banks); 
    free(ROM_banks); 
+   free(SRAM_cache);
 }
 
 int setup_MBC(int MBC_no, unsigned ram_banks, unsigned rom_banks, const char *filename) {
@@ -114,6 +144,12 @@ int setup_MBC(int MBC_no, unsigned ram_banks, unsigned rom_banks, const char *fi
         	log_message(LOG_ERROR, "Unable to allocate memory for RAM banks\n");
         	return 0;
     	}
+
+        SRAM_cache = malloc(ram_banks * RAM_BANK_SIZE);
+    	if (SRAM_cache == NULL) {
+        	log_message(LOG_ERROR, "Unable to allocate memory for SRAM cache\n");
+        	return 0;
+    	}
 	}
 
     ROM_banks = malloc(rom_banks * ROM_BANK_SIZE);
@@ -121,6 +157,9 @@ int setup_MBC(int MBC_no, unsigned ram_banks, unsigned rom_banks, const char *fi
         log_message(LOG_ERROR, "Unable to allocate memory for ROM banks\n");
         if (RAM_banks != NULL) {
 			free(RAM_banks);
+		}
+        if (SRAM_cache != NULL) {
+			free(SRAM_cache);
 		}
         return 0;
     }

--- a/src/core/mmu/mbc.h
+++ b/src/core/mmu/mbc.h
@@ -6,6 +6,10 @@
 #define RAM_BANK_SIZE 0x2000 // 8KB
 #define ROM_BANK_SIZE 0x4000 // 16KB
 
+// used to delay the SRAM_write() to file 
+// write to the SRAM file only if it's been XX seconds since we last wrote to it
+#define SRAM_WRITE_DELAY 60000 // 60 seconds
+
 extern uint8_t *RAM_banks;//[][0x2000];  // max 16 * 8KB ram banks (128KB) 0x2000
 extern uint8_t *ROM_banks;//[][0x4000];// max 512 * 16KB rom banks (8MB) 0x4000
 
@@ -41,6 +45,7 @@ void teardown_MBC();
 /* Writes/Reads ROM SRAM from file, used for
  * save games */
 void write_SRAM();
+void flush_SRAM();	// force write to file
 void read_SRAM();
 
 

--- a/src/non_core/files.h
+++ b/src/non_core/files.h
@@ -18,9 +18,18 @@ unsigned long load_rom_from_file(const char *file_path, unsigned char *data, siz
  * Buffer should be at minimum of size "MAX_SRAMS_SIZE" */
 unsigned long load_SRAM(const char *file_path, unsigned char *data, unsigned long size);
 
+/* Given a memory location, buffer, and size of the cache, attempts to load save data from cache into the buffer.
+ * Returns the size of the cache if successful, returns 0 if unsuccessful.
+ * Buffer should be at minimum of size "MAX_SRAMS_SIZE" */
+unsigned long load_SRAM_cached(unsigned char *cache_ptr, unsigned char *data, unsigned long size);
 
 /* Given a file_path, save data and the size of save data, attempts to
  * save the data to the given file. Returns 1 if successful, 0 otherwise */
 int save_SRAM(const char *file_path, const unsigned char *data, unsigned long size);
+
+/* Given memory location, save data and the size of save data, attempts to
+ * save the data to a cache in ram. Used to improve 3DS emulation speed 
+ * and lower the amount of taxing I/O writes. Returns 1 if successful, 0 otherwise */
+int save_SRAM_cached(unsigned char *cache_ptr, unsigned char *data, unsigned long size);
 
 #endif //FILES_H

--- a/src/platforms/3DS/files.c
+++ b/src/platforms/3DS/files.c
@@ -2,6 +2,7 @@
 #include "../../non_core/logger.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 /*  Given a file_path and buffer to store file data in, attempts to
  *  read the file into the buffer. Returns the size of the file if successful,
@@ -64,6 +65,20 @@ unsigned long load_SRAM(const char *file_path, unsigned char *data, unsigned lon
 
     return count;
 }
+
+/* Given a memory location, buffer, and size of the cache, attempts to load save data from cache into the buffer.
+ * Returns the size of the cache if successful, returns 0 if unsuccessful.
+ * Buffer should be at minimum of size "MAX_SRAMS_SIZE" */
+unsigned long load_SRAM_cached(unsigned char *cache_ptr, unsigned char *data, unsigned long size){
+
+    log_message(LOG_INFO, "Attempting to load SRAM from cache\n");
+    void* dest = memcpy(data, cache_ptr, size);
+    if(dest != NULL){
+        log_message(LOG_INFO, "%lu bytes successfully read from cache\n",size);
+        return size;
+    }
+    return 0;
+}
  
 
 /* Given a file_path, save data and the size of save data, attempts to
@@ -90,3 +105,16 @@ int save_SRAM(const char *file_path, const unsigned char *data, unsigned long si
     fclose(file);   
     return 1;
 }                                      
+
+/* Given memory location, save data and the size of save data, attempts to
+ * save the data to a cache in ram. Used to improve 3DS emulation speed 
+ * and lower the amount of taxing I/O writes. Returns 1 if successful, 0 otherwise */
+int save_SRAM_cached(unsigned char *cache_ptr, unsigned char *data, unsigned long size){
+    log_message(LOG_INFO, "Attempting to write SRAM cache\n");
+    void* dest = memcpy(cache_ptr, data, size);
+    if(dest != NULL){
+        log_message(LOG_INFO, "%lu bytes successfully written to cache\n",size);
+        return size;
+    }
+    return 0;
+}

--- a/src/platforms/3DS/main.c
+++ b/src/platforms/3DS/main.c
@@ -75,6 +75,7 @@ int main(int argc, char **argv) {
     }
 
     write_SRAM();
+    flush_SRAM();   // write straight to file on close
     cleanup();
 	return 0;
 }


### PR DESCRIPTION
Create new cache to store SRAM writes for 3DS. The cache is flushed to disk every 60 seconds.
Intended to fix #32 

- edited makefile for 3ds to include building of get_time.o
- used get_time to record time of SRAM write, only if 60 seconds since last write will memory write to file again
- added functions to load from SRAM cache and save SRAM cache and flush to SRAM file