### PR TITLE
Fix 3DS builds

### DIFF
--- a/build/3DS/Dockerfile
+++ b/build/3DS/Dockerfile
@@ -1,6 +1,6 @@
-from devkitpro/devkitarm:20230622
+from devkitpro/devkitarm:20240511
 
-RUN apt-get update && apt-get install -y gcc g++ zip
+RUN apt-get update && apt-get install -y gcc g++ zip cmake
 
 # Install makerom
 RUN cd / && git clone https://github.com/profi200/Project_CTR
@@ -8,10 +8,9 @@ RUN cd /Project_CTR/makerom && git checkout 8a9f9bda55d71274799eacf && make
 ENV PATH="/Project_CTR/makerom/:${PATH}"
 
 # Install bannertool
-RUN git config --global url."https://github.com/".insteadOf git://github.com/
-RUN cd / && git clone https://github.com/Steveice10/bannertool
-RUN cd /bannertool && git submodule update --init --recursive && make 
-ENV PATH="/bannertool/output/linux-x86_64/:${PATH}"
+RUN cd / && git clone https://github.com/carstene1ns/3ds-bannertool
+RUN cd /3ds-bannertool && cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo && cmake --build build
+ENV PATH="/3ds-bannertool/build/:${PATH}"
 
 RUN mkdir /plutoboy_3DS
 ADD . /plutoboy_3DS/


### PR DESCRIPTION
I wanted to give this a shot, and I noticed the 3DS builds were broken, from two issues:
1. The devkitarm docker image was no longer able to do `apt-get update`. A quick bump got that working
2. steveice10 deleted their github account, along with all repos! I switched to cartene1ns' repo. They are a developer on another project (easyrpg.org) that targets the 3DS, and they appear to be lightly maintaining a fork of 3ds-bannertool. Their fork switched to using cmake, hence the remaining changes.

At least locally, those got a working build again.